### PR TITLE
Fix infinate browser reloading

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -344,7 +344,7 @@
             var cookies = document.cookie.split(";");  
             for(var i=0; i<cookies.length;i++){  
                 var arr=cookies[i].split("=");  
-                if(arr[0]==name){  
+                if(arr[0].trim()==name){  
                     return unescape(arr[1]);  
                 }  
             }  


### PR DESCRIPTION
现在首页的 js 有 bug 会导致页面不停地刷新。这是因为有些浏览器在分隔 cookie 时用的是 `空格+;`, 而不是 `;` 判断 cookie 时，要先把首尾的空格去掉。